### PR TITLE
added torch.cuda.set_device for GPU devices

### DIFF
--- a/adaptive.py
+++ b/adaptive.py
@@ -126,6 +126,10 @@ class AdaptiveLossFunction(nn.Module):
       float_dtype = torch.float64
     self.float_dtype = float_dtype
     self.device = device
+    if isinstance(device, int) or\
+       (isinstance(device, str) and 'cuda' in device) or\
+       (isinstance(device, torch.device) and device.type == 'cuda'):
+        torch.cuda.set_device(self.device)
 
     self.distribution = distribution.Distribution()
 
@@ -244,6 +248,10 @@ class StudentsTLossFunction(nn.Module):
       float_dtype = torch.float64
     self.float_dtype = float_dtype
     self.device = device
+    if isinstance(device, int) or\
+       (isinstance(device, str) and 'cuda' in device) or\
+       (isinstance(device, torch.device) and device.type == 'cuda'):
+        torch.cuda.set_device(self.device)
 
     self.log_df = torch.nn.Parameter(
         torch.zeros(
@@ -411,8 +419,11 @@ class AdaptiveImageLossFunction(nn.Module):
     if float_dtype == np.float64:
       float_dtype = torch.float64
     self.float_dtype = float_dtype
-
     self.device = device
+    if isinstance(device, int) or\
+       (isinstance(device, str) and 'cuda' in device) or\
+       (isinstance(device, torch.device) and device.type == 'cuda'):
+        torch.cuda.set_device(self.device)
 
     x_example = torch.zeros([1] + list(self.image_size)).type(self.float_dtype)
     x_example_mat = self.transform_to_mat(x_example)


### PR DESCRIPTION
Hi, really like your paper and the repo.

If someone is using this repo on a GPU that isn't `cuda:0`, and they haven't run `torch.cuda.set_device(X)` where X is their GPU, then all of the `torch.as_tensor(Y)` calls in `util.py` will be put on the wrong device and cause an error. Specifically this error:

> File "/home/relh/solar/robust_loss_pytorch/distribution.py", line 201, in nllfun
>     assert (scale >= 0).all()
> RuntimeError: CUDA error: an illegal memory access was encountered

Since the code in `adaptive.py` is structured around accepting a torch device, and PyTorch has 3 ways of passing a torch device (https://pytorch.org/docs/stable/tensor_attributes.html#torch.torch.device), this tiny fix checks for any of the 3, checks that they're a cuda device, and if so sets the device appropriately.

I'm no PyTorch guru, and I'm not sure if this a preferred method, but it works for me. It's not checking if torch.cuda.is_available() because I think that should crash a program.

On the other hand, maybe it shouldn't be the role of a library to call `torch.cuda.set_device`.